### PR TITLE
fix/jest-config: Add jest config to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
     "flow": "flow",
     "prepublish": "npm run clean && npm run build && npm run test"
   },
+  "jest": {
+    "verbose": true,
+    "testURL": "http://localhost/"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/hixme/hiflow.git"


### PR DESCRIPTION
Apparently, all the builds have been failing because of this missing piece of jest config.